### PR TITLE
Improve login security using cookies

### DIFF
--- a/robot_manager_server/src/auth.py
+++ b/robot_manager_server/src/auth.py
@@ -1,9 +1,10 @@
+import os
 import bcrypt
 import jwt
 from datetime import datetime, timedelta
 
 # 🔐 Configuración
-SECRET_KEY = "clave-secreta-super-segura"
+SECRET_KEY = os.getenv("SECRET_KEY", "change_this_secret")
 ALGORITHM = "HS256"
 EXPIRATION_MINUTES = 60
 

--- a/robot_manager_web_app/src/components/AuthContext.jsx
+++ b/robot_manager_web_app/src/components/AuthContext.jsx
@@ -6,27 +6,22 @@ export const AuthProvider = ({ children }) => {
   const [usuario, setUsuario] = useState(null);
   const [cargando, setCargando] = useState(true);
 
-  const logout = () => {
-    localStorage.removeItem("token");
+  const logout = async () => {
+    await fetch("http://localhost:8000/logout", {
+      method: "POST",
+      credentials: "include",
+    });
     setUsuario(null);
   };
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
-    if (!token) {
-      setCargando(false);
-      return;
-    }
-
-    fetch("http://localhost:8000/me", {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    fetch("http://localhost:8000/me", { credentials: "include" })
       .then((res) => {
         if (!res.ok) throw new Error("Token inválido");
         return res.json();
       })
       .then((data) => setUsuario(data))
-      .catch(() => localStorage.removeItem("token"))
+      .catch(() => {})
       .finally(() => setCargando(false));
   }, []);
 

--- a/robot_manager_web_app/src/components/MIssionVisor.jsx
+++ b/robot_manager_web_app/src/components/MIssionVisor.jsx
@@ -29,7 +29,7 @@ const MissionVisor = () => {
 
     // Get maps
     useEffect(() => {
-        fetch("http://localhost:8000/missions")
+        fetch("http://localhost:8000/missions", { credentials: "include" })
         .then((res) => res.json())
         .then((data) => setMissions(data))
         .catch((err) => console.error(err));
@@ -51,7 +51,8 @@ const MissionVisor = () => {
     };
     fetch("http://localhost:8000/missions", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },    
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify(nuevo),
     })
         .then((res) => res.json())
@@ -94,6 +95,7 @@ const MissionVisor = () => {
     fetch(`http://localhost:8000/missions/${idMissionUpdate}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify(modificacion),
     })
     .then((res) => {
@@ -138,6 +140,7 @@ const MissionVisor = () => {
     const handleDeleteMission = (id) => {
     fetch(`http://localhost:8000/missions/${id}`, {
         method: "DELETE",
+        credentials: "include",
     })
         .then((res) => res.json())
         .then((data) => {
@@ -196,7 +199,7 @@ const MissionVisor = () => {
     // ********************************************* WAYPOINTS ENDPOINTS *********************************************
 
     const getWaypoints = () => {
-        fetch("http://localhost:8000/waypoints")
+        fetch("http://localhost:8000/waypoints", { credentials: "include" })
             .then((res) => res.json())
             .then((data) => setWaypoints(data))
             .catch((err) => console.error(err));
@@ -286,6 +289,7 @@ const MissionVisor = () => {
         fetch(`http://localhost:8000/missions/${idMissionUpdate}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
+            credentials: "include",
             body: JSON.stringify(modificado),
         })
         .then(res => res.json())

--- a/robot_manager_web_app/src/components/ManVisor.jsx
+++ b/robot_manager_web_app/src/components/ManVisor.jsx
@@ -59,7 +59,8 @@ const ManVisor = () => {
     try {
 
       const stop = await fetch("http://localhost:8000/Emergency", {
-        method: "POST"
+        method: "POST",
+        credentials: "include"
       });
       const stopData = await stop.json();
       console.log("🛑 handleButtonEmergency pressed:", stopData);

--- a/robot_manager_web_app/src/components/MapList.jsx
+++ b/robot_manager_web_app/src/components/MapList.jsx
@@ -15,7 +15,7 @@ const MapList = () => {
 
   // Get maps
   useEffect(() => {
-    fetch("http://localhost:8000/maps")
+    fetch("http://localhost:8000/maps", { credentials: "include" })
       .then((res) => res.json())
       .then((data) => setMaps(data))
       .catch((err) => console.error(err));
@@ -30,6 +30,7 @@ const MapList = () => {
     fetch("http://localhost:8000/maps", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      credentials: "include",
       body: JSON.stringify(nuevo),
     })
       .then((res) => res.json())
@@ -46,6 +47,7 @@ const MapList = () => {
   const handleDeleteMap = (id) => {
     fetch(`http://localhost:8000/maps/${id}`, {
       method: "DELETE",
+      credentials: "include",
     })
       .then((res) => res.json())
       .then((data) => {
@@ -87,6 +89,7 @@ const MapList = () => {
     fetch(`http://localhost:8000/maps/${idMapaModificacion}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify(modificacion),
     })
     .then((res) => {

--- a/robot_manager_web_app/src/components/Register.jsx
+++ b/robot_manager_web_app/src/components/Register.jsx
@@ -34,6 +34,7 @@ const Register = ({ onRegisterSuccess }) => {
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: "include",
         body: JSON.stringify({ email, password, nombre }),
       });
 

--- a/robot_manager_web_app/src/components/RobotVisor.jsx
+++ b/robot_manager_web_app/src/components/RobotVisor.jsx
@@ -16,7 +16,7 @@ const RobotVisor = () => {
 
     // Get robots
     useEffect(() => {
-    fetch("http://localhost:8000/robots")
+    fetch("http://localhost:8000/robots", { credentials: "include" })
         .then((res) => res.json())
         .then((data) => setRobots(data))
         .catch((err) => console.error(err));
@@ -33,6 +33,7 @@ const RobotVisor = () => {
         fetch("http://localhost:8000/robots", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
+            credentials: "include",
             body: JSON.stringify(nuevo),
         })
             .then((res) => res.json())
@@ -58,6 +59,7 @@ const RobotVisor = () => {
         fetch(`http://localhost:8000/robots/${idRobotMoficacion}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
+            credentials: "include",
             body: JSON.stringify(modificacion),
         })
         .then((res) => {
@@ -100,6 +102,7 @@ const RobotVisor = () => {
     const handleDeleteRobot = (id) => {
     fetch(`http://localhost:8000/robots/${id}`, {
         method: "DELETE",
+        credentials: "include",
     })
         .then((res) => res.json())
         .then((data) => {

--- a/robot_manager_web_app/src/components/WaypointVisor.jsx
+++ b/robot_manager_web_app/src/components/WaypointVisor.jsx
@@ -26,7 +26,7 @@ const WaypointVisor = () => {
     // ********************************************* ENDPOINTS *********************************************
 
     useEffect(() => {
-        fetch("http://localhost:8000/waypoints")
+        fetch("http://localhost:8000/waypoints", { credentials: "include" })
             .then((res) => res.json())
             .then((data) => setWaypoints(data))
             .catch((err) => console.error(err));
@@ -53,6 +53,7 @@ const WaypointVisor = () => {
         fetch("http://localhost:8000/waypoints", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
+            credentials: "include",
             body: JSON.stringify(nuevo),
         })
             .then((res) => res.json())
@@ -104,6 +105,7 @@ const WaypointVisor = () => {
         fetch(`http://localhost:8000/waypoints/${idWaypointMoficacion}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
+            credentials: "include",
             body: JSON.stringify(modificacion),
         })
         .then((res) => {
@@ -128,6 +130,7 @@ const WaypointVisor = () => {
     const handleDeleteWaypoint = (id) => {
         fetch(`http://localhost:8000/waypoints/${id}`, {
             method: "DELETE",
+            credentials: "include",
         })
             .then((res) => res.json())
             .then((data) => {

--- a/robot_manager_web_app/src/pages/login.jsx
+++ b/robot_manager_web_app/src/pages/login.jsx
@@ -30,6 +30,7 @@ const Login = ({ onLoginSuccess, onSwitchToRegister }) => {
         headers: {
           "Content-Type": "application/json"
         },
+        credentials: "include",
         body: JSON.stringify({ email, password })
       });
 
@@ -38,9 +39,6 @@ const Login = ({ onLoginSuccess, onSwitchToRegister }) => {
       if (!response.ok) {
         throw new Error(data.detail || "Error al iniciar sesión");
       }
-
-      // ✅ Guardar token en localStorage
-      localStorage.setItem("token", data.access_token);
 
       // ✅ Notificar login exitoso
       onLoginSuccess();


### PR DESCRIPTION
## Summary
- load secret key from env vars
- configure allowed CORS origins
- issue JWT token in HttpOnly cookie and add logout endpoint
- update API routes to require authentication
- store auth token in cookie on the frontend
- update fetch calls to send credentials

## Testing
- `npm run lint` *(fails: many lint errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688a220aaa7c832e844580c534f4f23c